### PR TITLE
fix error boolean instead DateTime given

### DIFF
--- a/src/Parser/ZipOutputParser.php
+++ b/src/Parser/ZipOutputParser.php
@@ -67,6 +67,8 @@ class ZipOutputParser implements ParserInterface
                 $mtime = \DateTime::createFromFormat('H:i Y-m-d', $chunks[2]);
             }
 
+            ($mtime === false) && $mtime = new \DateTime($chunks[2]);
+
             $members[] = array(
                 'location'  => $chunks[3],
                 'size'      => $chunks[1],


### PR DESCRIPTION
This commit will be fix the following error: 
"TypeError" thrown in vendor/alchemy/zippy/src/Archive/Member.php on line 74
Argument 5 passed to Alchemy\Zippy\Archive\Member::__construct() must be an instance of DateTime, boolean given, called in vendor/alchemy/zippy/src/Adapter/ZipAdapter.php on line 126